### PR TITLE
Switching order of +force_install_dir and +login anonymous

### DIFF
--- a/advancemenu.sh
+++ b/advancemenu.sh
@@ -335,7 +335,7 @@ sleep 1
 #Download Valheim from steam
 tput setaf 1; echo "$INSTALL_BUILD_DOWNLOAD_INSTALL_STEAM_VALHEIM" ; tput setaf 9;
 sleep 1
-/home/steam/steamcmd +login anonymous +force_install_dir ${valheimInstallPath} +app_update 896660 validate +exit
+/home/steam/steamcmd +force_install_dir +login anonymous ${valheimInstallPath} +app_update 896660 validate +exit
 tput setaf 2; echo "$ECHO_DONE" ; tput setaf 9;
 sleep 1
 #build config for start_valheim.sh
@@ -387,7 +387,7 @@ StartLimitInterval=60s
 StartLimitBurst=3
 User=steam
 Group=steam
-ExecStartPre=/home/steam/steamcmd +login anonymous +force_install_dir ${valheimInstallPath} +app_update 896660 validate +exit
+ExecStartPre=/home/steam/steamcmd +force_install_dir +login anonymous ${valheimInstallPath} +app_update 896660 validate +exit
 ExecStart=${valheimInstallPath}/start_valheim.sh
 ExecReload=/bin/kill -s HUP \$MAINPID
 KillSignal=SIGINT
@@ -561,7 +561,7 @@ echo ""
 #if y, then continue, else cancel
 if [ "$confirmOfficialUpdates" == "y" ]; then
     tput setaf 2; echo "$FUNCTION_INSTALL_VALHEIM_UPDATE_APPLY_INFO" ; tput setaf 9; 
-    /home/steam/steamcmd +login anonymous +force_install_dir ${valheimInstallPath} +app_update 896660 validate +exit
+    /home/steam/steamcmd +force_install_dir +login anonymous ${valheimInstallPath} +app_update 896660 validate +exit
     chown -R steam:steam ${valheimInstallPath}
     echo ""
 else
@@ -1124,7 +1124,7 @@ StartLimitInterval=60s
 StartLimitBurst=3
 User=steam
 Group=steam
-ExecStartPre=/home/steam/steamcmd +login anonymous +force_install_dir ${valheimInstallPath} +app_update 896660 validate +exit
+ExecStartPre=/home/steam/steamcmd +force_install_dir +login anonymous ${valheimInstallPath} +app_update 896660 validate +exit
 EOF
 if [ "$valheimVanilla" == "1" ]; then
    echo "$FUNCTION_VALHEIM_PLUS_BUILD_CONFIG_SET_VANILLA"
@@ -1529,7 +1529,7 @@ StartLimitInterval=60s
 StartLimitBurst=3
 User=steam
 Group=steam
-ExecStartPre=/home/steam/steamcmd +login anonymous +force_install_dir ${valheimInstallPath} +app_update 896660 validate +exit
+ExecStartPre=/home/steam/steamcmd +force_install_dir +login anonymous ${valheimInstallPath} +app_update 896660 validate +exit
 EOF
 if [ "$valheimVanilla" == "1" ]; then
    echo "$FUNCTION_BEPINEX_BUILD_CONFIG_SET_VANILLA"

--- a/menu.sh
+++ b/menu.sh
@@ -340,7 +340,7 @@ sleep 1
 #Download Valheim from steam
 tput setaf 1; echo "$INSTALL_BUILD_DOWNLOAD_INSTALL_STEAM_VALHEIM" ; tput setaf 9;
 sleep 1
-/home/steam/steamcmd +login anonymous +force_install_dir ${valheimInstallPath} +app_update 896660 validate +exit
+/home/steam/steamcmd +force_install_dir +login anonymous ${valheimInstallPath} +app_update 896660 validate +exit
 tput setaf 2; echo "$ECHO_DONE" ; tput setaf 9;
 sleep 1
 #build config for start_valheim.sh
@@ -392,7 +392,7 @@ StartLimitInterval=60s
 StartLimitBurst=3
 User=steam
 Group=steam
-ExecStartPre=/home/steam/steamcmd +login anonymous +force_install_dir ${valheimInstallPath} +app_update 896660 validate +exit
+ExecStartPre=/home/steam/steamcmd +force_install_dir +login anonymous ${valheimInstallPath} +app_update 896660 validate +exit
 ExecStart=${valheimInstallPath}/start_valheim.sh
 ExecReload=/bin/kill -s HUP \$MAINPID
 KillSignal=SIGINT
@@ -564,7 +564,7 @@ echo ""
 #if y, then continue, else cancel
 if [ "$confirmOfficialUpdates" == "y" ]; then
     tput setaf 2; echo "$FUNCTION_INSTALL_VALHEIM_UPDATE_APPLY_INFO" ; tput setaf 9; 
-    /home/steam/steamcmd +login anonymous +force_install_dir ${valheimInstallPath} +app_update 896660 validate +exit
+    /home/steam/steamcmd +force_install_dir +login anonymous ${valheimInstallPath} +app_update 896660 validate +exit
     chown -R steam:steam ${valheimInstallPath}
     echo ""
 else
@@ -600,7 +600,7 @@ function check_apply_server_updates_beta() {
 #    echo ""
 #    echo "$FUNCTION_APPLY_SERVER_UPDATES"
 #      [ ! -d /opt/valheimtemp ] && mkdir -p /opt/valheimtemp
-#      /home/steam/steamcmd +login anonymous +force_install_dir /opt/valheimtemp +app_update 896660 validate +exit
+#      /home/steam/steamcmd +force_install_dir +login anonymous /opt/valheimtemp +app_update 896660 validate +exit
 #      sed -e 's/[\t ]//g;/^$/d' /opt/valheimtemp/steamapps/appmanifest_896660.acf > appmanirepo.log
 #      repoValheim=$(sed -n '11p' appmanirepo.log)
 #      echo "$FUNCTION_APPLY_SERVER_UPDATES_OFFICIAL_VALHEIM_REPO $repoValheim"

--- a/njordmenu.sh
+++ b/njordmenu.sh
@@ -522,7 +522,7 @@ StartLimitInterval=60s
 StartLimitBurst=3
 User=steam
 Group=steam
-ExecStartPre=$steamexe +login anonymous +force_install_dir ${valheimInstallPath}/${worldname} +app_update 896660 validate +exit
+ExecStartPre=$steamexe +force_install_dir +login anonymous ${valheimInstallPath}/${worldname} +app_update 896660 validate +exit
 ExecStart=${valheimInstallPath}/${worldname}/start_valheim_${worldname}.sh
 ExecReload=/bin/kill -s HUP \$MAINPID
 KillSignal=SIGINT
@@ -968,7 +968,7 @@ function nocheck_valheim_update_install() {
 
 	tput setaf 1; echo "$INSTALL_BUILD_DOWNLOAD_INSTALL_STEAM_VALHEIM" ; tput setaf 9;
 	sleep 1
-	$steamexe +login anonymous +force_install_dir ${valheimInstallPath}/${worldname} +app_update 896660 validate +exit
+	$steamexe +force_install_dir +login anonymous ${valheimInstallPath}/${worldname} +app_update 896660 validate +exit
 	tput setaf 2; echo "$ECHO_DONE" ; tput setaf 9;
 }
 
@@ -993,7 +993,7 @@ $(ColorRed ''"$DRAW60"'')"
 	#if y, then continue, else cancel
 	if [ "$confirmOfficialUpdates" == "y" ]; then
 		tput setaf 2; echo "$FUNCTION_INSTALL_VALHEIM_UPDATE_APPLY_INFO" ; tput setaf 9; 
-		$steamexe +login anonymous +force_install_dir ${valheimInstallPath}/${worldname} +app_update 896660 validate +exit
+		$steamexe +force_install_dir +login anonymous ${valheimInstallPath}/${worldname} +app_update 896660 validate +exit
 		chown -R steam:steam ${valheimInstallPath}/${worldname}
 		echo ""
 	else
@@ -2042,7 +2042,7 @@ StartLimitInterval=60s
 StartLimitBurst=3
 User=steam
 Group=steam
-ExecStartPre=$steamexe +login anonymous +force_install_dir ${valheimInstallPath}/${worldname} +app_update 896660 validate +exit
+ExecStartPre=$steamexe +force_install_dir +login anonymous ${valheimInstallPath}/${worldname} +app_update 896660 validate +exit
 EOF
 if [ "$valheimVanilla" == "1" ]; then
    echo "$FUNCTION_VALHEIM_PLUS_BUILD_CONFIG_SET_VANILLA"
@@ -2451,7 +2451,7 @@ StartLimitInterval=60s
 StartLimitBurst=3
 User=steam
 Group=steam
-ExecStartPre=$steamexe +login anonymous +force_install_dir ${valheimInstallPath}/${worldname} +app_update 896660 validate +exit
+ExecStartPre=$steamexe +force_install_dir +login anonymous ${valheimInstallPath}/${worldname} +app_update 896660 validate +exit
 EOF
 if [ "$valheimVanilla" == "1" ]; then
    echo "$FUNCTION_BEPINEX_BUILD_CONFIG_SET_VANILLA"
@@ -2804,7 +2804,7 @@ StartLimitInterval=60s
 StartLimitBurst=3
 User=steam
 Group=steam
-ExecStartPre=$steamexe +login anonymous +force_install_dir ${valheimInstallPath}/${worldname} +app_update 896660 validate +exit
+ExecStartPre=$steamexe +force_install_dir +login anonymous ${valheimInstallPath}/${worldname} +app_update 896660 validate +exit
 ExecStart=${valheimInstallPath}/${worldname}/start_valheim_${worldname}.sh
 ExecReload=/bin/kill -s HUP \$MAINPID
 KillSignal=SIGINT


### PR DESCRIPTION
There is a warning in SteamCMD that suggests you use the +force_install_dir command before you log in.

See here:
https://github.com/ValveSoftware/steam-for-linux/issues/8298